### PR TITLE
Rework RSpec module with enable/disable methods

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -21,7 +21,7 @@ RSpec/ExampleLength:
     - 'spec/unit/db_minter_spec.rb'
     - 'spec/unit/file_minter_spec.rb'
 
-# Offense count: 5
+# Offense count: 6
 # Configuration parameters: CustomTransform.
 RSpec/FilePath:
   Exclude:
@@ -30,12 +30,18 @@ RSpec/FilePath:
     - 'spec/unit/file_minter_spec.rb'
     - 'spec/unit/noid_spec.rb'
     - 'spec/unit/service_spec.rb'
+    - 'spec/unit/rspec_spec.rb'
 
 # Offense count: 9
 RSpec/LeadingSubject:
   Exclude:
     - 'spec/unit/config_spec.rb'
     - 'spec/unit/file_minter_spec.rb'
+
+# Offense count: 3
+RSpec/InstanceVariable:
+  Exclude:
+    - 'spec/unit/rspec_spec.rb'
 
 # Offense count: 4
 RSpec/MessageChain:
@@ -64,12 +70,13 @@ RSpec/NamedSubject:
     - 'spec/unit/noid_spec.rb'
     - 'spec/unit/service_spec.rb'
 
-# Offense count: 11
+# Offense count: 12
 # Configuration parameters: MaxNesting.
 RSpec/NestedGroups:
   Exclude:
     - 'spec/unit/config_spec.rb'
     - 'spec/unit/noid_spec.rb'
+    - 'spec/unit/rspec_spec.rb'
 
 # Offense count: 3
 # Configuration parameters: IgnoreSymbolicNames.

--- a/README.md
+++ b/README.md
@@ -132,8 +132,15 @@ $ rake active_fedora:noid:migrate:database_to_file
 
 **NOTE 2**: If you decide to use the database-backed minter, you may notice that your test suite now fails miserably if it is configured to clear out the application database between tests. If so, you may add the following to e.g. `spec/spec_helper.rb` to set the default minter in the test suite as the file-backed one:
 
-``` ruby
+```ruby
 require 'active_fedora/noid/rspec'
+
+RSpec.configure do |config|
+  config.include(ActiveFedora::Noid::RSpec)
+end
+
+before(:suite) { disable_production_minter! }
+after(:suite)  { enable_production_minter! }
 ```
 
 ### Identifier template

--- a/lib/active_fedora/noid/rspec.rb
+++ b/lib/active_fedora/noid/rspec.rb
@@ -1,8 +1,66 @@
 # frozen_string_literal: true
-RSpec.configure do |config|
-  config.before(:suite) do
-    ActiveFedora::Noid.configure do |noid_config|
-      noid_config.minter_class = ActiveFedora::Noid::Minter::File
+module ActiveFedora
+  module Noid
+    ##
+    # Provides a test minter conforming to the `ActiveFedora::Noid::Minter`
+    # interface for use in unit tests. The test minter is faster and avoids
+    # unexpected interactions with cleanup code commonly runs in test suites
+    # (e.g. database cleanup).
+    #
+    # Applications should reenable their production minter for integration tests
+    # when appropriate
+    #
+    # @example general use
+    #   ActiveFedora::Noid::RSpec.disable_production_minter!
+    #   # some unit tests with the test minter
+    #   ActiveFedora::Noid::RSpec.enable_production_minter!
+    #   # some integration tests with the original minter
+    #
+    # @example using a custom test minter
+    #   ActiveFedora::Noid::RSpec.disable_production_minter!(test_minter: Minter)
+    #
+    # @example use when included in RSpec config
+    #   require 'active_fedora/noid/rspec'
+    #
+    #   RSpec.configure do |config|
+    #     config.include(ActiveFedora::Noid::RSpec)
+    #   end
+    #
+    #   before(:suite) { disable_production_minter! }
+    #   after(:suite)  { enable_production_minter! }
+    #
+    module RSpec
+      DEFAULT_TEST_MINTER = ActiveFedora::Noid::Minter::File
+
+      ##
+      # Replaces the configured production minter with a test minter.
+      #
+      # @param test_minter [Class] an ActiveFedora::Noid::Minter implementation
+      #   to use as a replacement minter
+      # @return [void]
+      def disable_production_minter!(test_minter: DEFAULT_TEST_MINTER)
+        return nil if @original_minter
+
+        @original_minter = ActiveFedora::Noid.config.minter_class
+
+        ActiveFedora::Noid.configure do |noid_config|
+          noid_config.minter_class = test_minter
+        end
+      end
+
+      ##
+      # Re-enables the original configured minter.
+      #
+      # @return [void]
+      def enable_production_minter!
+        return nil unless @original_minter
+
+        ActiveFedora::Noid.configure do |noid_config|
+          noid_config.minter_class = @original_minter
+        end
+
+        @original_minter = nil
+      end
     end
   end
 end

--- a/spec/unit/rspec_spec.rb
+++ b/spec/unit/rspec_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+require 'active_fedora/noid/rspec'
+
+describe ActiveFedora::Noid::RSpec do
+  include described_class
+
+  let(:configured_minter) { @configured_minter }
+  let(:var_name)          { :@original_minter }
+
+  before do
+    @configured_minter = Class.new(ActiveFedora::Noid::Minter::Base)
+    @reset_minter      = ActiveFedora::Noid.config.minter_class
+
+    ActiveFedora::Noid.configure do |noid_config|
+      noid_config.minter_class = @configured_minter
+    end
+  end
+
+  after do
+    ActiveFedora::Noid.configure do |noid_config|
+      noid_config.minter_class = @reset_minter
+    end
+  end
+
+  describe '#disable_production_minter!' do
+    it 'changes the configured minter' do
+      expect { disable_production_minter! }
+        .to change { ActiveFedora::Noid.config.minter_class }
+        .from(configured_minter)
+        .to described_class::DEFAULT_TEST_MINTER
+    end
+
+    it 'accepts custom test minter at call time' do
+      my_minter = Class.new(ActiveFedora::Noid::Minter::Base)
+
+      expect { disable_production_minter!(test_minter: my_minter) }
+        .to change { ActiveFedora::Noid.config.minter_class }
+        .from(configured_minter)
+        .to my_minter
+    end
+
+    it 'does not overwrite stored minter on second call' do
+      disable_production_minter!
+
+      expect { disable_production_minter! }
+        .not_to change { described_class.instance_variable_get(var_name) }
+    end
+
+    it 'still reenables after second call' do
+      2.times { disable_production_minter! }
+      expect { enable_production_minter! }
+        .to change { ActiveFedora::Noid.config.minter_class }
+        .from(described_class::DEFAULT_TEST_MINTER).to configured_minter
+    end
+
+    it 'disables after reenable' do
+      disable_production_minter!
+      enable_production_minter!
+      expect { disable_production_minter! }
+        .to change { ActiveFedora::Noid.config.minter_class }
+        .from(configured_minter).to described_class::DEFAULT_TEST_MINTER
+    end
+  end
+
+  describe '#enable_production_minter!' do
+    it 'does nothing when already enabled' do
+      expect { enable_production_minter! }
+        .not_to change { ActiveFedora::Noid.config.minter_class }
+    end
+
+    context 'with minter disabled' do
+      before { disable_production_minter! }
+
+      it 'reenables the originally configured minter' do
+        expect { enable_production_minter! }
+          .to change { ActiveFedora::Noid.config.minter_class }
+          .from(described_class::DEFAULT_TEST_MINTER)
+          .to configured_minter
+      end
+
+      it 'enables after re-disable' do
+        enable_production_minter!
+        disable_production_minter!
+        expect { enable_production_minter! }
+          .to change { ActiveFedora::Noid.config.minter_class }
+          .from(described_class::DEFAULT_TEST_MINTER).to configured_minter
+      end
+    end
+  end
+end


### PR DESCRIPTION
Provides a stable interface for enabling/disabling the production minter in tests. With these changes, users will need to explicitly disable their default minter in the test suite.

Replaces #48.