### PR TITLE
Remove db:migrate from the generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,11 @@ The database-based minter stores minter state information in your application's 
 $ rails generate active_fedora:noid:install
 ```
 
-This will create the necessary database tables and seed the database minter. To start minting identifiers with the new minter, override the AF::Noid configuration in e.g. `config/initializers/active_fedora-noid.rb`:
+This will create the necessary database migrations.
+
+Then run `rake db:migrate`
+
+To start minting identifiers with the new minter, override the AF::Noid configuration in e.g. `config/initializers/active_fedora-noid.rb`:
 
 ```ruby
 require 'active_fedora/noid'

--- a/lib/generators/active_fedora/noid/install_generator.rb
+++ b/lib/generators/active_fedora/noid/install_generator.rb
@@ -14,11 +14,6 @@ Copies DB migrations
 
       def migrations
         rake 'active_fedora_noid_engine:install:migrations'
-        rake 'db:migrate'
-      end
-
-      def seed
-        generate 'active_fedora:noid:seed'
       end
     end
   end

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -10,5 +10,6 @@ class TestAppGenerator < Rails::Generators::Base
 
   def install_engine
     generate 'active_fedora:noid:install'
+    rake 'db:migrate'
   end
 end


### PR DESCRIPTION
The generator should only be run once (to make the migrations)
but db:migrate must be run in every environment.  This keeps that
consistent and matches the patterns used by other gems that generate
database tables (see Devise for one such example).  As seeds are now
autocreated, that step is no longer necessary either.