### PR TITLE
next_id should only query once inside the transaction

### DIFF
--- a/lib/active_fedora/noid/minter/base.rb
+++ b/lib/active_fedora/noid/minter/base.rb
@@ -8,15 +8,13 @@ module ActiveFedora
       class Base < ::Noid::Minter
         ##
         # @param template [#to_s] a NOID template
-        #
         # @see Noid::Template
         def initialize(template = default_template)
           super(template: template.to_s)
         end
 
         ##
-        # Sychronously mint a new identifier. Guarantees the ID is not
-        # already reserved in ActiveFedora.
+        # Sychronously mint a new identifier. Guarantees the ID is not already reserved in ActiveFedora.
         #
         # @return [String] the minted identifier
         def mint
@@ -29,7 +27,7 @@ module ActiveFedora
         end
 
         ##
-        # @return [Hash] an object representing the current minter state
+        # @return [Hash{Symbol => String, Object}] representation of the current minter state
         def read
           raise NotImplementedError, 'Implement #read in child class'
         end
@@ -38,7 +36,6 @@ module ActiveFedora
         # Updates the minter state to that of the `minter` parameter.
         #
         # @param minter [Minter::Base]
-        #
         # @return [void]
         def write!(_)
           raise NotImplementedError, 'Implement #write! in child class'
@@ -53,7 +50,7 @@ module ActiveFedora
         end
 
         ##
-        # @return [String] a new identifier.
+        # @return [String] a new identifier
         def next_id
           raise NotImplementedError, 'Implement #next_id in child class'
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,4 +20,5 @@ RSpec.configure do |config|
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
   end
+  config.filter_run_when_matching :focus
 end

--- a/spec/support/shared_examples/minter.rb
+++ b/spec/support/shared_examples/minter.rb
@@ -14,14 +14,9 @@ shared_examples 'a minter' do
       expect(described_class.new.valid?(subject)).to be true
     end
 
-    it 'is invalid under a different template' do
-      expect(described_class.new('.reedddk').valid?(subject)).to be false
-    end
-
     context 'with a different template' do
-      let(:other) { described_class.new('.reedddk') }
-      it 'is invalid under a different template' do
-        expect(other).not_to be_valid(minter.mint)
+      it 'is invalid' do
+        expect(described_class.new('.reedddk').valid?(subject)).to be false
       end
     end
   end


### PR DESCRIPTION
Fixes #66

This preserves the API as it stands.  Basically `read` and `write!` are for "outsiders" that only know about `Noid::Minter`.  The `serialize` and `deserialize` methods are the meat.  

If it is agreeable, I might go further to make `write!` look like:

```ruby
def write!(minter, inst = instance)
  inst.update_attributes!(
    seq: minter.seq,
    counters: JSON.generate(minter.counters),
    rand: Marshal.dump(minter.instance_variable_get(:@rand))
  )
end
```
Then it can replace `serialize` completely.